### PR TITLE
Support being a pre-commit check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: copyright
+  name: Auto-add copyright header
+  description: This hook auto-adds copyright header
+  entry: copyright
+  language: python
+  types: [text]
+  args: [-S, -q, -c, .copyright.config.json]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,3 @@
   entry: copyright
   language: python
   types: [text]
-  args: [-S, -q, -c, .copyright.config.json]

--- a/copyright/cli.py
+++ b/copyright/cli.py
@@ -106,7 +106,8 @@ copyright -c options.json file1 dir2/*
             '-y', '--year',
             help='''Year(s) to be injected into template. Defaults to current.''')
 
-        parser.add_argument('files', help='List of files to process.')
+        parser.add_argument('files', nargs='*',
+                            help='List of files to process.')
 
         return parser
 

--- a/copyright/lang.py
+++ b/copyright/lang.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import copyright
 import os
 import re
@@ -214,14 +215,17 @@ class XmlLang(Lang):
                 start='<!--', stop='-->', keywords=keywords)
 
 def langs():
-    return dict(
-        c=CLang(),
-        go=GoLang(),
-        java=JavaLang(),
-        py=PyLang(),
-        sh=ShLang(),
-        sql=SqlLang(),
-        xml=XmlLang())
+    return OrderedDict([
+        ('c', CLang()),
+        ('go', GoLang()),
+        ('java', JavaLang()),
+        ('py', PyLang()),
+        ('sh', ShLang()),
+        # Must check xml BEFORE sql because existing XMl close comment will get
+        # seen as a single-line SQL comment.  Oops.
+        ('xml', XmlLang()),
+        ('sql', SqlLang()),
+    ])
 
 class Detector:
     langs = langs()
@@ -229,10 +233,8 @@ class Detector:
     @staticmethod
     def detect(filename, autodetect=False):
         '''Return None or lang family name.'''
-        names = list(Detector.langs.keys())
-        names.sort()
-        for name in names:
-            if Detector.langs[name].isa(filename, autodetect):
+        for name, lang_instance in Detector.langs.items():
+            if lang_instance.isa(filename, autodetect):
                 return name
         return None
 

--- a/copyright/license.py
+++ b/copyright/license.py
@@ -17,9 +17,11 @@ class LicensedFile:
     def write(self, back=False, newlines=1):
         '''Write text to file.'''
         if not self.file or not self.lic or not os.path.exists(self.file):
-            return
+            return 0  # nothing changed
 
-        text = self.lang.strip(file=self.file)
+        with open(self.file, 'r') as f:
+            orig_text = f.read()
+        text = self.lang.strip(text=orig_text)
         sep = os.linesep * newlines
         if back:
             text = text.rstrip('\r\n') + sep + self.lic
@@ -34,8 +36,15 @@ class LicensedFile:
 
             text = ''.join([head, self.lic, tail])
 
-        with open(self.file, 'w') as f:
-            f.write(text)
+        # Never let an extraneous newline at end-of-file go out
+        if text.endswith('\n\n'):
+            text = text[:-1]
+
+        if text != orig_text:
+            with open(self.file, 'w') as f:
+                f.write(text)
+            return 1  # changed something
+        return 0  # nothing changed
 
 # copyright - Add or replace license boilerplate.
 # Copyright (C) 2016 Remik Ziemlinski

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
     author='Remik Ziemlinski',
     author_email='first.last@gmail.com',
     license='GPLv3',
-    scripts=['scripts/copyright'],
     url='https://www.github.com/rsmz/copyright',
     download_url='https://github.com/rsmz/copyright/archive/copyright-1.0.1.0.tar.gz',
+    entry_points={
+        'console_scripts': ['copyright=copyright.app:main'],
+    },
 )


### PR DESCRIPTION
Also, for some reason the "files" argument was missing a nargs="*"

Exit non-zero if any files were modified; pre-commit expects this

Also fix bug where existing, good XML files would get detected as SQL and
have a busted copyright header added.

Also also, don't allow an extra trailing newline to get added to a file.